### PR TITLE
Update anchor-idl.md

### DIFF
--- a/content/anchor-idl/en/anchor-idl.md
+++ b/content/anchor-idl/en/anchor-idl.md
@@ -93,7 +93,7 @@ it("Should sub", async () => {
 });
 ```
 
-**Exercise:** Implement similar functions for `mul`, `div`, and `mod`, and write a unit test to trigger each one.
+**Exercise:** Implement similar functions for `mul`, `div`, and `modulo`, and write a unit test to trigger each one.
 
 ## What about the `Initialize` struct?
 


### PR DESCRIPTION
`mod` is a keyword in rust, program won't compile using `mod` as a function name, changed into `modulo`