### PR TITLE
Edit Solana CLI installation instructions

### DIFF
--- a/content/hello-world-solana/en/hello-world-solana.md
+++ b/content/hello-world-solana/en/hello-world-solana.md
@@ -26,10 +26,11 @@ corepack enable # corepack comes with node js
 
 ### Install the Solana cli
 We strongly recommend using the `stable` version, not `latest`.
+Solana installation no longer supports symbolic channel names (`edge`, `beta`, `stable`), hence we have to specify the version.
 
 ```
 # install solana
-sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+sh -c "$(curl -sSfL https://release.solana.com/v1.16.25/install)"
 ```
 
 ### Install Anchor
@@ -182,11 +183,6 @@ You can change the Anchor version by running:
 ```bash
 avm install 0.29.0
 avm use 0.29.0
-```
-You can change the Solana version simply by specifying the version in the curl command:
-```
-# install solana
-sh -c "$(curl -sSfL https://release.solana.com/1.16.25/install)"
 ```
 
 ### error: package `solana-program v1.18.0` cannot be built


### PR DESCRIPTION
Installing Solana via channel names is no longer supported
- Fixed the installation command by specifying the version number.
- Removed the appropriate section in the Troubleshooting guide to reflect this change.

<img width="840" alt="Screenshot 2024-08-27 at 3 29 02 PM" src="https://github.com/user-attachments/assets/8d0b1825-160e-4814-ba5a-9596b2715e40">
