### PR TITLE
Add note about getParsedTransaction vs getTransaction

### DIFF
--- a/content/solana-logs-transaction-history/en/solana-logs-transaction-history.md
+++ b/content/solana-logs-transaction-history/en/solana-logs-transaction-history.md
@@ -145,6 +145,6 @@ let myAddress = "enter and address here";
 getTransactions(myAddress, 3);
 ```
 
-Note that the actual content of the transaction is retrieved using the `getParsedTransaction` RPC method.
+Note that the actual content of the transaction is retrieved using the `getParsedTransaction` RPC method, which is only supported in the `@solana/web3.js` SDK. For other libraries, see `getTransaction` instead.
 
 *Originally Published February, 20, 2024*


### PR DESCRIPTION
Updated the documentation to clarify that the `getParsedTransaction` method is only supported in the `@solana/web3.js` SDK. 