### PR TITLE
Change non-zero to zero lamport balance

### DIFF
--- a/content/init-if-needed-anchor/init-if-needed-anchor.md
+++ b/content/init-if-needed-anchor/init-if-needed-anchor.md
@@ -92,7 +92,7 @@ But before we just silence the error, we should understand what a re-initializat
 If we try to initialize an account that has already been initialized, the transaction will fail.
 
 ## How does Anchor know an account is already initialized?
-From Anchor's perspective, if the account has a non-zero lamport balance OR the account is owned by the system program, then it is not initialized.
+From Anchor's perspective, if the account has a zero lamport balance OR the account is owned by the system program, then it is not initialized.
 
 An account owned by the system program or with zero lamport balance can be initialized again.
 


### PR DESCRIPTION
Fixes account initialization explanation - an account is uninitialized if it has a zero lamport balance or is owned by the system program.