### PR TITLE
fix: use buyer_ata instead of buyer_token_account in mint instruction

### DIFF
--- a/content/spl-token-sale-tutorial/spl-token-sale-tutorial.md
+++ b/content/spl-token-sale-tutorial/spl-token-sale-tutorial.md
@@ -294,7 +294,7 @@ The code does the following:
         // Setup mint instruction with mint as its own authority
         let mint_to_instruction = MintTo {
             mint: ctx.accounts.mint.to_account_info(),
-            to: ctx.accounts.buyer_token_account.to_account_info(),
+            to: ctx.accounts.buyer_ata.to_account_info(),
             authority: ctx.accounts.mint.to_account_info(),
         };
 


### PR DESCRIPTION
## Issue: Incorrect account name in MintTo instruction

### Description
In the `mint()` function code example, the `MintTo` instruction references `buyer_token_account`, but this account name doesn't match the actual account defined in the `MintTokens` struct.

### Location
File: `content/spl-token-sale-tutorial/spl-token-sale-tutorial.md`

### Current Code
```rust
let mint_to_instruction = MintTo {
    mint: ctx.accounts.mint.to_account_info(),
    to: ctx.accounts.buyer_token_account.to_account_info(),  // ❌ Incorrect
    authority: ctx.accounts.mint.to_account_info(),
};
Expected Code
let mint_to_instruction = MintTo {
    mint: ctx.accounts.mint.to_account_info(),
    to: ctx.accounts.buyer_ata.to_account_info(),  // ✅ Correct
    authority: ctx.accounts.mint.to_account_info(),
};
```

### Reason

The MintTokens struct (defined later in the tutorial) uses buyer_ata as the account name:

```rust
#[derive(Accounts)]
pub struct MintTokens<'info> {
    // ...
    pub buyer_ata: Account<'info, TokenAccount>,
    // ...
}
```