### PR TITLE
fix: spl-token-sale-tutorial add missing helper functions in test setup

### DIFF
--- a/content/spl-token-sale-tutorial/spl-token-sale-tutorial.md
+++ b/content/spl-token-sale-tutorial/spl-token-sale-tutorial.md
@@ -189,6 +189,19 @@ import * as web3 from "@solana/web3.js";
 import { assert } from "chai";
 import { TokenSale } from "../target/types/token_sale";
 
+// Helper functions for token conversions
+function toRawTokenAmount(amount: number): number {
+  return amount * 1e9;
+}
+
+function toDisplayAmount(amount: number): number {
+  return amount / 1e9;
+}
+
+function lamportsToSol(lamports: number | anchor.BN): number {
+  return Number(lamports) / 1e9;
+}
+
 describe("token_sale", async () => {
   const provider = anchor.AnchorProvider.env();
   anchor.setProvider(provider);


### PR DESCRIPTION
## Add missing helper functions in token sale tutorial

### Summary
This PR adds the missing helper function definitions (`toRawTokenAmount`, `toDisplayAmount`, and `lamportsToSol`) that are used throughout the test cases but were never defined in the tutorial.

### Problem
Users following the tutorial would encounter errors when running the tests because these helper functions are called in multiple places:
- `lamportsToSol(solToSend)` and `toDisplayAmount(expectedTokenAmount)`
- `toRawTokenAmount(1000)`
- `toDisplayAmount(currentSupply)` and `toDisplayAmount(remainingSupply)`
- `toRawTokenAmount(20)`
- `lamportsToSol()` calls

### Solution
Added three helper functions at the beginning of the test file (after imports, before the `describe` block):

1. **`toRawTokenAmount(amount: number)`**
2. **`toDisplayAmount(amount: number)`**
3. **`lamportsToSol(lamports: number | anchor.BN)`**

### Testing
Users can now successfully run all test cases without encountering "function not defined" errors.